### PR TITLE
Add Python version matrix to pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,9 +10,12 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv python install
+      - run: uv python install ${{ matrix.python-version }}
       - run: uv sync
       - run: uv run pytest -vv


### PR DESCRIPTION
## Summary

- Added a matrix strategy to the pytest workflow to test across Python versions 3.9, 3.10, 3.11, 3.12, and 3.13
- Updated the `uv python install` step to use the matrix Python version
- This ensures comprehensive testing across all supported Python versions as specified in `pyproject.toml` (`requires-python = ">=3.9"`)

## Changes

- Modified `.github/workflows/pytest.yml` to include a `strategy.matrix` configuration
- Tests will now run 5 times in parallel, once for each Python version

## Test Plan

- [ ] Verify that the GitHub Actions workflow runs successfully
- [ ] Confirm that all 5 Python version jobs execute in the workflow
- [ ] Check that tests pass on all Python versions (3.9-3.13)

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)