### PR TITLE
test: 13 tests for BasePipeline.apply_limit and initialize_client

### DIFF
--- a/tests/test_base_pipeline.py
+++ b/tests/test_base_pipeline.py
@@ -1,0 +1,157 @@
+"""Tests for syntk.pipelines.base — BasePipeline.apply_limit and initialize_client."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Tuple, Type
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from syntk.pipelines.base import BasePipeline
+from syntk.config import (
+    APIArguments,
+    BaseDataArguments,
+    BaseProcessingArguments,
+    GenerationArguments,
+    ConfigArguments,
+)
+from syntk.tracking import TrackingArguments
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass for testing
+# ---------------------------------------------------------------------------
+
+class _MinimalPipeline(BasePipeline):
+    def get_argument_classes(self) -> Tuple[Type, ...]:
+        return ()
+
+    def setup_dataframe(self, df, resuming):
+        return df
+
+    def process_row(self, row, idx):
+        return {}
+
+    def get_config_params(self):
+        return {}
+
+    def get_rows_to_process(self, df):
+        return list(df.index)
+
+
+def _make_pipeline(limit=None) -> _MinimalPipeline:
+    p = _MinimalPipeline()
+    p.data_args = BaseDataArguments(
+        input_file="dummy.csv",
+        output_file="dummy_out.csv",
+        limit=limit,
+    )
+    p.api_args = APIArguments()
+    p.gen_args = GenerationArguments()
+    p.proc_args = BaseProcessingArguments()
+    p.track_args = TrackingArguments()
+    p.config_args = ConfigArguments()
+    return p
+
+
+def _df(n: int = 10) -> pd.DataFrame:
+    return pd.DataFrame({"x": list(range(n))})
+
+
+# ---------------------------------------------------------------------------
+# apply_limit
+# ---------------------------------------------------------------------------
+
+class TestApplyLimit:
+    def test_none_limit_returns_full_df(self):
+        p = _make_pipeline(limit=None)
+        df = _df(10)
+        result = p.apply_limit(df)
+        assert len(result) == 10
+
+    def test_integer_limit_truncates(self):
+        p = _make_pipeline(limit=5)
+        result = p.apply_limit(_df(10))
+        assert len(result) == 5
+
+    def test_integer_limit_larger_than_df(self):
+        """Limit larger than df → returns all rows."""
+        p = _make_pipeline(limit=100)
+        result = p.apply_limit(_df(10))
+        assert len(result) == 10
+
+    def test_fraction_limit_truncates(self):
+        """0 < limit < 1 is treated as a fraction."""
+        p = _make_pipeline(limit=0.5)
+        result = p.apply_limit(_df(10))
+        assert len(result) == 5
+
+    def test_fraction_limit_small(self):
+        p = _make_pipeline(limit=0.1)
+        result = p.apply_limit(_df(100))
+        assert len(result) == 10
+
+    def test_zero_limit_raises(self):
+        p = _make_pipeline(limit=0)
+        with pytest.raises(ValueError, match="[Ll]imit"):
+            p.apply_limit(_df(10))
+
+    def test_negative_limit_raises(self):
+        p = _make_pipeline(limit=-1)
+        with pytest.raises(ValueError, match="[Ll]imit"):
+            p.apply_limit(_df(10))
+
+    def test_limit_one_keeps_one_row(self):
+        p = _make_pipeline(limit=1)
+        result = p.apply_limit(_df(10))
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# initialize_client
+# ---------------------------------------------------------------------------
+
+class TestInitializeClient:
+    def test_uses_env_api_key(self, monkeypatch):
+        p = _make_pipeline()
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-abc")
+        with patch("syntk.pipelines.base.OpenAI") as mock_openai:
+            p.initialize_client()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["api_key"] == "test-key-abc"
+
+    def test_uses_base_url_from_api_args(self, monkeypatch):
+        p = _make_pipeline()
+        p.api_args.base_url = "http://myserver:8080/v1"
+        monkeypatch.setenv("OPENAI_API_KEY", "key")
+        with patch("syntk.pipelines.base.OpenAI") as mock_openai:
+            p.initialize_client()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["base_url"] == "http://myserver:8080/v1"
+
+    def test_placeholder_key_when_env_missing(self, monkeypatch):
+        p = _make_pipeline()
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("syntk.pipelines.base.OpenAI") as mock_openai:
+            p.initialize_client()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["api_key"] == "placeholder-api-key"
+
+    def test_client_set_on_instance(self, monkeypatch):
+        p = _make_pipeline()
+        monkeypatch.setenv("OPENAI_API_KEY", "key")
+        fake_client = MagicMock()
+        with patch("syntk.pipelines.base.OpenAI", return_value=fake_client):
+            p.initialize_client()
+        assert p.client is fake_client
+
+    def test_custom_api_key_env_var(self, monkeypatch):
+        p = _make_pipeline()
+        p.api_args.api_key_env = "MY_CUSTOM_KEY"
+        monkeypatch.setenv("MY_CUSTOM_KEY", "custom-secret")
+        with patch("syntk.pipelines.base.OpenAI") as mock_openai:
+            p.initialize_client()
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["api_key"] == "custom-secret"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,149 @@
+"""Tests for syntk.io — save_dataframe, load_dataframe, find_available_column_name."""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _df(rows: int = 3) -> pd.DataFrame:
+    return pd.DataFrame({"id": list(range(rows)), "text": [f"row{i}" for i in range(rows)]})
+
+
+# ---------------------------------------------------------------------------
+# save_dataframe / load_dataframe — format roundtrips
+# ---------------------------------------------------------------------------
+
+class TestSaveLoadRoundtrip:
+    def test_csv_roundtrip(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.csv")
+        df = _df()
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert list(loaded.columns) == list(df.columns)
+        assert len(loaded) == len(df)
+
+    def test_tsv_roundtrip(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.tsv")
+        df = _df()
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert len(loaded) == len(df)
+
+    def test_json_roundtrip(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.json")
+        df = _df()
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert len(loaded) == len(df)
+
+    def test_jsonl_roundtrip(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.jsonl")
+        df = _df()
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert len(loaded) == len(df)
+
+    def test_parquet_roundtrip(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.parquet")
+        df = _df()
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert len(loaded) == len(df)
+        assert list(loaded["id"]) == list(df["id"])
+
+    def test_case_insensitive_extension(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.CSV")
+        df = _df(2)
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert len(loaded) == 2
+
+
+# ---------------------------------------------------------------------------
+# save_dataframe — edge cases
+# ---------------------------------------------------------------------------
+
+class TestSaveDataframe:
+    def test_creates_output_directory(self, tmp_path):
+        from syntk.io import save_dataframe
+        nested = str(tmp_path / "nested" / "dir" / "out.csv")
+        save_dataframe(_df(), nested)
+        assert os.path.exists(nested)
+
+    def test_unsupported_format_raises_value_error(self, tmp_path):
+        from syntk.io import save_dataframe
+        with pytest.raises(ValueError, match="Unsupported"):
+            save_dataframe(_df(), str(tmp_path / "data.xlsx"))
+
+    def test_csv_no_index_column(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "out.csv")
+        save_dataframe(_df(), path)
+        loaded = load_dataframe(path)
+        # No "Unnamed: 0" index column
+        assert "Unnamed: 0" not in loaded.columns
+
+
+# ---------------------------------------------------------------------------
+# load_dataframe — edge cases
+# ---------------------------------------------------------------------------
+
+class TestLoadDataframe:
+    def test_unsupported_format_raises_value_error(self, tmp_path):
+        from syntk.io import load_dataframe
+        with pytest.raises(ValueError, match="Unsupported"):
+            load_dataframe(str(tmp_path / "data.xlsx"))
+
+    def test_preserves_column_names(self, tmp_path):
+        from syntk.io import save_dataframe, load_dataframe
+        path = str(tmp_path / "data.parquet")
+        df = pd.DataFrame({"alpha": [1], "beta": [2], "gamma": [3]})
+        save_dataframe(df, path)
+        loaded = load_dataframe(path)
+        assert set(loaded.columns) == {"alpha", "beta", "gamma"}
+
+
+# ---------------------------------------------------------------------------
+# find_available_column_name
+# ---------------------------------------------------------------------------
+
+class TestFindAvailableColumnName:
+    def test_returns_base_when_not_present(self):
+        from syntk.io import find_available_column_name
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        assert find_available_column_name(df, "c") == "c"
+
+    def test_returns_name_1_when_base_taken(self):
+        from syntk.io import find_available_column_name
+        df = pd.DataFrame({"output": [1]})
+        assert find_available_column_name(df, "output") == "output_1"
+
+    def test_increments_past_taken_suffixes(self):
+        from syntk.io import find_available_column_name
+        df = pd.DataFrame({"output": [1], "output_1": [2]})
+        assert find_available_column_name(df, "output") == "output_2"
+
+    def test_no_collision_on_empty_df(self):
+        from syntk.io import find_available_column_name
+        df = pd.DataFrame()
+        assert find_available_column_name(df, "result") == "result"
+
+    def test_large_suffix_skip(self):
+        """Skips all taken suffixes up to the first available one."""
+        from syntk.io import find_available_column_name
+        cols = {"x": [1], "x_1": [2], "x_2": [3], "x_3": [4]}
+        df = pd.DataFrame(cols)
+        assert find_available_column_name(df, "x") == "x_4"


### PR DESCRIPTION
## Summary
- Adds 13 pytest unit tests for `src/syntk/pipelines/base.py`
- Covers `apply_limit`: None (pass-through), integer count, fraction, limit larger than df, zero/negative → ValueError
- Covers `initialize_client`: env key used, base_url forwarded, placeholder key when env missing, client set on instance, custom env var name

## Test plan
- [ ] `pytest tests/test_base_pipeline.py` passes with all 13 tests green
- [ ] Uses a minimal concrete subclass (`_MinimalPipeline`) to satisfy abstract methods

🤖 Contributed by [hai-pilgrim](https://github.com/hai-pilgrim)