### PR TITLE
fix: don't AttributeError on response.usage=None in debug log

### DIFF
--- a/src/syntk/api_client.py
+++ b/src/syntk/api_client.py
@@ -97,9 +97,16 @@ def get_chat_response(
         if content and len(content) > 200
         else f"API Response: {content}"
     )
-    logger.debug(
-        f"API Call - Tokens used: prompt={response.usage.prompt_tokens}, completion={response.usage.completion_tokens}, total={response.usage.total_tokens}"
-    )
+    # Not every OpenAI-compatible server returns usage — some llama.cpp / vLLM
+    # configurations omit it for streaming-style responses, in which case
+    # response.usage is None and attribute access would AttributeError out of
+    # a debug log. Skip the token log instead of crashing the call.
+    if response.usage is not None:
+        logger.debug(
+            f"API Call - Tokens used: prompt={response.usage.prompt_tokens}, "
+            f"completion={response.usage.completion_tokens}, "
+            f"total={response.usage.total_tokens}"
+        )
 
     result = {
         "content": content,

--- a/tests/test_get_chat_response.py
+++ b/tests/test_get_chat_response.py
@@ -186,3 +186,14 @@ class TestGetChatResponse:
             result = get_chat_response(client, "q", "gpt-4")
         assert result["content"] is None
         assert any("None" in r.message or "none" in r.message.lower() for r in caplog.records)
+
+    def test_none_usage_does_not_crash(self):
+        """Some OpenAI-compatible servers (certain llama.cpp / vLLM configs)
+        return response.usage=None. The defensive token-debug log must not
+        AttributeError out of the call."""
+        response = _make_response()
+        response.usage = None
+        client = _make_client(response)
+        # Should return cleanly — no AttributeError on response.usage.prompt_tokens
+        result = get_chat_response(client, "q", "gpt-4")
+        assert result["content"] == "hello"


### PR DESCRIPTION
## Bug

\`get_chat_response\` (\`src/syntk/api_client.py:100-102\`) unconditionally accesses \`response.usage.prompt_tokens\` etc. inside a debug log line:

\`\`\`python
logger.debug(
    f\"API Call - Tokens used: prompt={response.usage.prompt_tokens}, ...\"
)
\`\`\`

Some OpenAI-compatible servers return \`response.usage = None\` (certain llama.cpp / vLLM streaming-mode configs are documented to omit usage). The attribute access on \`None\` crashes the entire \`get_chat_response\` call — not just suppresses the log line.

## Fix

Gates the log on \`response.usage is not None\`. The actual call result is unchanged when usage is missing. Reformats the f-string across multiple lines while we're touching it.

## Test

\`test_none_usage_does_not_crash\` pins the contract: a mocked response with \`usage=None\` returns cleanly with the expected content, no AttributeError.

322 → 323 tests, all green.