### PR TITLE
feat(io): auto-create private HF dataset repo for hf:// output paths (re-land of #23)

### DIFF
--- a/src/syntk/io.py
+++ b/src/syntk/io.py
@@ -4,11 +4,29 @@ import os
 import pandas as pd
 
 
+def _ensure_hf_dataset_repo_exists(output_file: str) -> None:
+    """For hf://datasets/<owner>/<repo>/... paths, create the dataset repo
+    (private, exist_ok=True) so the subsequent write doesn't FileNotFoundError
+    when the repo hasn't been created yet. Lazy-imports huggingface_hub so it's
+    not required for local-path callers."""
+    rest = output_file[len("hf://datasets/"):]
+    parts = rest.split("/")
+    if len(parts) < 2:
+        return
+    repo_id = f"{parts[0]}/{parts[1]}"
+    try:
+        from huggingface_hub import create_repo
+        create_repo(repo_id, repo_type="dataset", private=True, exist_ok=True)
+    except Exception:
+        pass
+
+
 def save_dataframe(df: pd.DataFrame, output_file: str) -> None:
     """Save dataframe to file, detecting format from extension.
 
     Supported formats: .parquet, .csv, .json, .jsonl, .tsv
-    Creates output directories if needed.
+    Creates output directories if needed. For hf://datasets/owner/repo/...
+    paths, auto-creates the dataset repo if it doesn't exist yet.
 
     Args:
         df: DataFrame to save
@@ -17,10 +35,12 @@ def save_dataframe(df: pd.DataFrame, output_file: str) -> None:
     Raises:
         ValueError: If file format is not supported
     """
-    # Ensure output directory exists
-    output_dir = os.path.dirname(output_file)
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
+    if output_file.startswith("hf://datasets/"):
+        _ensure_hf_dataset_repo_exists(output_file)
+    else:
+        output_dir = os.path.dirname(output_file)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
 
     output_file_lower = output_file.lower()
     if output_file_lower.endswith(".parquet"):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -147,3 +147,86 @@ class TestFindAvailableColumnName:
         cols = {"x": [1], "x_1": [2], "x_2": [3], "x_3": [4]}
         df = pd.DataFrame(cols)
         assert find_available_column_name(df, "x") == "x_4"
+
+
+# ---------------------------------------------------------------------------
+# save_dataframe — hf:// dataset repo auto-create
+# ---------------------------------------------------------------------------
+
+class TestSaveDataframeHfAutoCreate:
+    def _install_fake_hf_hub(self, monkeypatch, captured):
+        """Inject a fake `huggingface_hub` into sys.modules whose create_repo
+        records its call args into `captured` — covers io._ensure_hf_dataset_repo_exists's
+        lazy `from huggingface_hub import create_repo`."""
+        import sys
+        import types
+        fake = types.ModuleType("huggingface_hub")
+        def fake_create_repo(repo_id, repo_type, private, exist_ok):
+            captured.append({"repo_id": repo_id, "repo_type": repo_type,
+                             "private": private, "exist_ok": exist_ok})
+        fake.create_repo = fake_create_repo
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+
+    def test_extracts_owner_repo_from_hf_path(self, monkeypatch):
+        from syntk.io import _ensure_hf_dataset_repo_exists
+        captured = []
+        self._install_fake_hf_hub(monkeypatch, captured)
+        _ensure_hf_dataset_repo_exists("hf://datasets/myowner/myrepo/data/out.tsv")
+        assert len(captured) == 1
+        assert captured[0]["repo_id"] == "myowner/myrepo"
+
+    def test_uses_dataset_repo_type_private_existok(self, monkeypatch):
+        from syntk.io import _ensure_hf_dataset_repo_exists
+        captured = []
+        self._install_fake_hf_hub(monkeypatch, captured)
+        _ensure_hf_dataset_repo_exists("hf://datasets/owner/repo/file.tsv")
+        assert captured[0]["repo_type"] == "dataset"
+        assert captured[0]["private"] is True
+        assert captured[0]["exist_ok"] is True
+
+    def test_no_call_when_path_lacks_owner_or_repo(self, monkeypatch):
+        from syntk.io import _ensure_hf_dataset_repo_exists
+        captured = []
+        self._install_fake_hf_hub(monkeypatch, captured)
+        _ensure_hf_dataset_repo_exists("hf://datasets/onlyowner")  # missing /repo
+        assert captured == []
+
+    def test_silently_swallows_create_repo_errors(self, monkeypatch):
+        """If the network/token is missing, _ensure_hf_dataset_repo_exists
+        should not raise — the subsequent write will surface a more useful error."""
+        import sys
+        import types
+        fake = types.ModuleType("huggingface_hub")
+        def boom(**kwargs):
+            raise RuntimeError("simulated auth failure")
+        fake.create_repo = boom
+        monkeypatch.setitem(sys.modules, "huggingface_hub", fake)
+        from syntk.io import _ensure_hf_dataset_repo_exists
+        # Must not raise
+        _ensure_hf_dataset_repo_exists("hf://datasets/owner/repo/x.csv")
+
+    def test_save_dataframe_routes_hf_paths_through_ensure(self, monkeypatch, tmp_path):
+        """End-to-end-ish: save_dataframe with an hf:// path should call
+        _ensure_hf_dataset_repo_exists, then route the actual write through
+        pandas as usual (which we stub here to avoid touching the network)."""
+        from syntk import io
+        captured = []
+        self._install_fake_hf_hub(monkeypatch, captured)
+        # Replace to_csv so the test doesn't actually try to hit hf://
+        write_calls = []
+        monkeypatch.setattr(
+            pd.DataFrame, "to_csv",
+            lambda self, *a, **kw: write_calls.append((a, kw)),
+        )
+        df = pd.DataFrame({"x": [1, 2]})
+        io.save_dataframe(df, "hf://datasets/own/rep/data/out.csv")
+        assert len(captured) == 1
+        assert captured[0]["repo_id"] == "own/rep"
+        assert len(write_calls) == 1
+
+    def test_save_dataframe_does_not_call_ensure_for_local_paths(self, monkeypatch, tmp_path):
+        from syntk import io
+        captured = []
+        self._install_fake_hf_hub(monkeypatch, captured)
+        io.save_dataframe(pd.DataFrame({"x": [1]}), str(tmp_path / "out.csv"))
+        assert captured == []


### PR DESCRIPTION
**Draft re-land of #23** — hai-pilgrim's original PR was 3 months stale (opened 2026-03-28) and its single commit included a `Co-Authored-By: Claude` trailer (per repo convention, those don't ship). Ported the `io.py` change as-is and rewrote the tests against current `tests/test_io.py` to use `monkeypatch.setitem(sys.modules, ...)` instead of the original's direct `sys.modules` mutation.

## Summary
When `save_dataframe` is called with an `hf://datasets/<owner>/<repo>/...` path and the dataset repo doesn't exist yet, the underlying write raises `FileNotFoundError`. This adds `_ensure_hf_dataset_repo_exists` which lazy-imports `huggingface_hub.create_repo` with `private=True`, `exist_ok=True` so the subsequent write lands cleanly.

Lazy import — callers writing to local paths don't pay the import cost and don't need huggingface_hub installed.

Closes #21.

## Test plan
- [x] `uv run --with pytest pytest -q` → 329 passed (including 6 new `TestSaveDataframeHfAutoCreate` tests)
- [x] `uvx ruff check` clean
- [ ] CI / your review

Opening as draft because it's a re-land, not my own work — your call whether to ready-for-review, squash, or close + ask hai-pilgrim to rebase #23 directly. Closing #23 once this lands is the cleanest path.