### PR TITLE
fix(column): coerce None API content to '' so resume terminates (#45)

### DIFF
--- a/src/syntk/pipelines/column.py
+++ b/src/syntk/pipelines/column.py
@@ -184,8 +184,13 @@ class ColumnPipeline(BasePipeline):
             )
             self.responses[prompt] = api_result
 
-        # Build result dict with columns to save
-        result = {self.data_args.output_column: api_result["content"]}
+        # Build result dict with columns to save. Coerce a None content to ""
+        # so a row that was processed but produced no content (e.g. content-
+        # filter rejections, some local-LLM edge cases) is not seen as
+        # unprocessed and retried forever on resume (#45) — get_rows_to_process
+        # already treats empty strings as processed.
+        content = api_result["content"]
+        result = {self.data_args.output_column: content if content is not None else ""}
 
         # Add reasoning content if column specified
         if self.data_args.reasoning_content_column:

--- a/tests/test_process_row.py
+++ b/tests/test_process_row.py
@@ -66,6 +66,29 @@ class TestProcessRow:
             result = pipeline.process_row(row, idx=0)
         assert result["generated"] == "a response"
 
+    def test_none_content_coerced_to_empty_string(self):
+        # None content must be written as "" not None, else the row looks
+        # unprocessed (NaN) and is retried forever on resume (#45).
+        pipeline = _make_pipeline()
+        row = self._row(text="hi")
+        api_result = _make_api_result(content=None)
+        with patch("syntk.pipelines.column.get_chat_response", return_value=api_result):
+            result = pipeline.process_row(row, idx=0)
+        assert result["generated"] == ""
+
+    def test_none_result_row_not_reprocessed_on_resume(self):
+        # End-to-end of the resume gate: a row whose generation yielded None
+        # content is considered processed and not picked up again (#45).
+        pipeline = _make_pipeline()
+        api_result = _make_api_result(content=None)
+        with patch("syntk.pipelines.column.get_chat_response", return_value=api_result):
+            res = pipeline.process_row(pd.Series({"text": "hi"}), idx=0)
+        df = pd.DataFrame({"text": ["hi"]})
+        df["generated"] = pd.NA
+        for col, val in res.items():
+            df.at[0, col] = val
+        assert pipeline.get_rows_to_process(df) == []
+
     def test_formats_prompt_from_template(self):
         pipeline = _make_pipeline(prompt_template="Summarize: {text}")
         row = self._row(text="the quick fox")


### PR DESCRIPTION
Fixes #45 — None-content rows were re-processed on every resume forever (`pd.isna(None)` is True, so the resume gate never saw them as done).

**Fix:** coerce `None` content to `""` at the write site in `process_row`. `get_rows_to_process` already treats empty strings as processed, so the row terminates. +2 deterministic tests (both fail against the old passthrough); full suite **325/325**.

**Design note (your call):** the issue leaned toward option (1) — keep `None`, record `stop_reason`, and have the resume gate honor it. I went with option (2) instead because **(1) is incomplete**: `stop_reason` is only written when `save_stop_reason=True` (default False), so with the default config the resume gate would still have no signal and the bug would persist. Option (2) is the only *self-contained* complete fix. **Tradeoff:** it changes a None result to `""` in the output column (the "why" is still preserved in `stop_reason` when that's enabled). Happy to switch to (1) — or (1)+(2) — if you'd rather preserve `None` and accept the save_stop_reason dependency. (hivemind idle fix)