### PR TITLE
fix(column): reuse pipeline-owned stop_reason column on resume (#44)

### DIFF
--- a/src/syntk/pipelines/column.py
+++ b/src/syntk/pipelines/column.py
@@ -108,6 +108,27 @@ class ColumnPipeline(BasePipeline):
             "save_interval": self.proc_args.save_interval,
         }
 
+    def _resolve_stop_reason_column(self, df: pd.DataFrame, resuming: bool) -> str:
+        """Pick the column to write generated stop-reasons into.
+
+        Fresh run: allocate the first free ``stop_reason`` name. Resume: reuse
+        the column this pipeline wrote last time instead of allocating a new
+        suffix — otherwise stop-reasons split across ``stop_reason``,
+        ``stop_reason_1``, ... on every resume (#44). The pipeline-owned column
+        is the candidate whose populated rows line up exactly with the output
+        column's (``process_row`` writes both together), which distinguishes it
+        from a pre-existing user column of the same name.
+        """
+        base = "stop_reason"
+        out_col = self.data_args.output_column
+        if resuming and out_col in df.columns:
+            out_mask = df[out_col].notna()
+            if out_mask.any():
+                for c in df.columns:
+                    if (c == base or c.startswith(base + "_")) and df[c].notna().equals(out_mask):
+                        return c
+        return find_available_column_name(df, base)
+
     def setup_dataframe(self, df: pd.DataFrame, resuming: bool) -> pd.DataFrame:
         """Initialize output columns."""
         # Initialize output column if not resuming
@@ -116,7 +137,7 @@ class ColumnPipeline(BasePipeline):
 
         # Initialize optional stop reason column
         if self.data_args.save_stop_reason:
-            self.actual_stop_reason_column = find_available_column_name(df, "stop_reason")
+            self.actual_stop_reason_column = self._resolve_stop_reason_column(df, resuming)
             if not resuming or self.actual_stop_reason_column not in df.columns:
                 df[self.actual_stop_reason_column] = pd.NA
             logger.info(f"Stop reasons will be saved to column: {self.actual_stop_reason_column}")

--- a/tests/test_column_pipeline.py
+++ b/tests/test_column_pipeline.py
@@ -88,6 +88,32 @@ class TestSetupDataframe:
         pipeline.setup_dataframe(df, resuming=False)
         assert pipeline.actual_stop_reason_column is None
 
+    def test_resume_reuses_pipeline_stop_reason_column(self):
+        # On resume, reuse the stop_reason column written last run instead of
+        # allocating a new suffix that splits the data across runs (#44).
+        pipeline = _make_pipeline(output_column="out", save_stop_reason=True)
+        # Run 1's partial output: row 0 processed (out + stop_reason both set).
+        df = pd.DataFrame({
+            "text": ["a", "b"],
+            "out": ["gen-0", pd.NA],
+            "stop_reason": ["stop", pd.NA],
+        })
+        pipeline.setup_dataframe(df, resuming=True)
+        assert pipeline.actual_stop_reason_column == "stop_reason"
+
+    def test_resume_reuses_owned_column_despite_user_collision(self):
+        # If the input had a user 'stop_reason' column, Run 1 wrote to
+        # 'stop_reason_1'; resume must reuse that, not allocate 'stop_reason_2'.
+        pipeline = _make_pipeline(output_column="out", save_stop_reason=True)
+        df = pd.DataFrame({
+            "text": ["a", "b"],
+            "stop_reason": ["user-x", "user-y"],   # user's full column
+            "out": ["gen-0", pd.NA],
+            "stop_reason_1": ["stop", pd.NA],       # pipeline-owned, partial
+        })
+        pipeline.setup_dataframe(df, resuming=True)
+        assert pipeline.actual_stop_reason_column == "stop_reason_1"
+
     def test_adds_reasoning_content_column_when_specified(self):
         pipeline = _make_pipeline(reasoning_content_column="reasoning")
         df = pd.DataFrame({"text": ["a"]})


### PR DESCRIPTION
Fixes #44.

**⚠️ Severity is higher than the issue states — verified.** The issue frames this as niche ('requires a user stop_reason column collision'). It isn't: with **no** user collision, Run 1 writes `stop_reason`, and on resume Run 2 sees `stop_reason` already exists and allocates `stop_reason_1` — splitting the data. So it corrupts **every** `save_stop_reason=True` resume. I confirmed with a no-collision repro (Run1→`stop_reason`, Run2→`stop_reason_1`). This also means the issue's **option 3 (fail-fast on any `stop_reason*` column) would break all legitimate resumes**, since the pipeline's own column matches.

**Fix (issue option 1):** on resume, reuse the pipeline-owned column instead of re-allocating. The owned column is the `stop_reason`/`stop_reason_N` candidate whose populated rows line up exactly with the output column's (`process_row` writes both together) — which distinguishes it from a pre-existing full user column. Fresh runs are unchanged. +2 tests (no-collision reuse + collision reuse), both fail against the old code; full suite **325/325**.

**Design note (your call):** this is the detection approach. It's heuristic — the edge case is a resume where 0 rows were processed yet (no signal; falls back to allocating) or a user column that coincidentally shares the output null-pattern. If you'd prefer determinism, issue option 2 (a `{output_file}.meta.json` sidecar recording the chosen column) is robust but adds a file. Happy to switch. (hivemind idle fix)