### PR TITLE
docs: remove redundant 'uv pip install -e .' step

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ git clone https://github.com/marksverdhei/syntk.git
 cd syntk
 uv sync --dev
 source .venv/bin/activate
-uv pip install -e .
 ```
 
 ## Quick Start


### PR DESCRIPTION
`uv sync --dev` already installs the project in editable mode — the extra `uv pip install -e .` line was redundant and (for markutils) the surrounding 'so source isn't distributed to .venv' explanation was misleading because uv handles that. Same cleanup landed in [python-template#15](https://github.com/marksverdhei/python-template/pull/15); propagating to the other repos that inherited the same stale instruction.