### PR TITLE
docs: document the new bootstrap pipeline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A synthetic data toolkit for generating and augmenting datasets using Large Lang
 ### Key Features
 
 - **Column Pipeline**: Fill dataset columns with LLM-generated values
+- **Bootstrap Pipeline**: Grow a tabular dataset by N rows via few-shot LLM prompting
 - **Flexible Data Formats**: Support for Parquet, CSV, JSON, JSONL, and TSV
 - **OpenAI-Compatible APIs**: Works with OpenAI, OpenRouter, and any compatible endpoint
 - **Resume Support**: Automatically resumes interrupted processing
@@ -178,9 +179,26 @@ aim up --repo ./logs
 
 ## Available Pipelines
 
-- **`column`**: Fill dataset columns with LLM-generated values
+- **`column`**: Fill dataset columns with LLM-generated values from a prompt template.
+- **`bootstrap`**: Grow a tabular dataset by `N` rows using few-shot LLM prompting — for each new row, sample `n_shots` existing rows as in-context examples and ask the model to generate one more in the same style. Optionally appends to the source.
 
-More pipelines coming soon!
+### Bootstrap example
+
+```bash
+syntk bootstrap \
+  --input-file data.parquet \
+  --output-file data_bootstrapped.parquet \
+  --n 100 \
+  --n-shots 5 \
+  --model gpt-4o \
+  --seed 42
+```
+
+Standard `APIArguments` / `GenerationArguments` flags (`--model`, `--temperature`, `--max-tokens`, `--base-url`, etc.) all apply, and a YAML config file may be passed positionally (same shape as the column pipeline). Useful knobs specific to bootstrap:
+
+- `--columns text,label` — restrict generation to a subset of columns; others are populated `None`.
+- `--append False` — write only the generated rows to `--output-file` instead of `input + generated`.
+- `--system-prompt "..."` — override the default JSON-row instruction.
 
 ## Development
 


### PR DESCRIPTION
\`#51\` (the bootstrap re-land) landed today but \`README.md\` still said *\"More pipelines coming soon!\"* under **Available Pipelines** and didn't mention bootstrap anywhere.

This PR:
- Adds **Bootstrap Pipeline** as a bullet under **Key Features** alongside Column Pipeline
- Replaces the *\"coming soon\"* line in **Available Pipelines** with a real description and a copy-paste example invocation
- Documents the 3 bootstrap-specific knobs callers actually need: \`--columns\` (subset), \`--append False\` (only-generated output), \`--system-prompt\` (override the default JSON-row instruction)

CLI surface verified against \`src/syntk/pipelines/bootstrap.py\`:\`BootstrapDataArguments\` — \`n\` / \`n_shots\` / \`columns\` / \`seed\` / \`system_prompt\` / \`append\`.

No code changes.