### PR TITLE
docs: document hf:// dataset paths for input_file / output_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Run your pipeline:
 syntk column your_config.yaml
 ```
 
+### Hugging Face dataset paths (`hf://`)
+
+`input_file` and `output_file` both accept `hf://datasets/<owner>/<repo>/<path>` URIs in addition to local paths. Reads stream the parquet/JSONL files straight from the Hub via `huggingface_hub`. Writes to an `hf://datasets/...` URI auto-create the dataset repo if it doesn't exist yet (private, with `exist_ok=True`), so the first run won't FileNotFoundError on a missing repo. Authentication uses the same `HF_TOKEN` environment variable the `huggingface_hub` CLI does.
+
+```yaml
+input_file: "hf://datasets/ltg/norec_sentence/ternary/train-00000-of-00001.parquet"
+output_file: "hf://datasets/marksverdhei/norec-annotated/train.parquet"
+```
+
 ### Command-Line Options
 
 Override any config file setting via command-line:


### PR DESCRIPTION
#47 (auto-create private HF dataset repo on write) landed yesterday and existing example configs use `hf://` for input_file, but neither path was documented in the README. Adds a 'Hugging Face dataset paths' section between 'Creating Your Own Pipeline' and 'Command-Line Options' explaining:

- Both `input_file` and `output_file` accept `hf://datasets/<owner>/<repo>/...`
- Reads stream from the Hub via huggingface_hub
- Writes auto-create the repo if missing (#47 behaviour, private + exist_ok=True)
- Auth uses `HF_TOKEN` (the huggingface_hub CLI's standard env var)

Tiny example showing both sides of the URI in a config snippet. No code change.