### PR TITLE
fix(bootstrap): actually load the positional YAML config

### DIFF
--- a/src/syntk/pipelines/bootstrap.py
+++ b/src/syntk/pipelines/bootstrap.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
+import yaml
 from tqdm import trange
 from transformers import HfArgumentParser
 
@@ -195,6 +196,23 @@ def bootstrap(
     return pd.DataFrame(new_rows, columns=columns)
 
 
+def _merge_yaml_config(config_file: str, arg_objects: list, arg_classes: tuple) -> None:
+    """Load a flattened YAML config and merge it into already-parsed dataclass
+    instances, with CLI values taking precedence over YAML over defaults.
+
+    Mirrors BasePipeline._merge_yaml_config so a positional `config.yaml` is
+    honoured by `syntk bootstrap` exactly as it is by the column pipeline.
+    """
+    with open(config_file, "r") as f:
+        config_dict = yaml.safe_load(f) or {}
+    yaml_args = HfArgumentParser(arg_classes).parse_dict(config_dict, allow_extra_keys=True)
+    for args_obj, yaml_obj in zip(arg_objects, yaml_args):
+        for field_name in args_obj.__dataclass_fields__:
+            default_value = args_obj.__dataclass_fields__[field_name].default
+            if getattr(args_obj, field_name) == default_value:  # CLI left it at default
+                setattr(args_obj, field_name, getattr(yaml_obj, field_name))
+
+
 def main() -> None:
     """Entry point for syntk bootstrap."""
     logging.basicConfig(
@@ -203,12 +221,14 @@ def main() -> None:
     )
 
     # Support positional YAML config
+    config_file = None
     args_to_parse = None
     if (
         len(sys.argv) > 1
         and sys.argv[1].endswith((".yaml", ".yml"))
         and not sys.argv[1].startswith("--")
     ):
+        config_file = sys.argv[1]
         args_to_parse = sys.argv[2:]
 
     parser = HfArgumentParser(
@@ -217,6 +237,15 @@ def main() -> None:
     config_args, api_args, gen_args, data_args = parser.parse_args_into_dataclasses(
         args=args_to_parse
     )
+
+    # Load + merge the positional YAML (CLI overrides YAML overrides defaults).
+    # Without this the YAML was parsed off the front of argv and silently ignored.
+    if config_file:
+        _merge_yaml_config(
+            config_file,
+            [api_args, gen_args, data_args],
+            (APIArguments, GenerationArguments, BootstrapDataArguments),
+        )
 
     # Initialize client
     api_key = os.getenv(api_args.api_key_env)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -209,3 +209,45 @@ class TestBootstrap:
         assert len(result) == 3
         # After the first row, pool grows — later prompts may include generated rows
         # (The test just verifies no crash and correct count)
+
+
+# ---------------------------------------------------------------------------
+# _merge_yaml_config — positional YAML support (README: "same shape as column")
+# ---------------------------------------------------------------------------
+
+class TestMergeYamlConfig:
+    def _merge(self, tmp_path, config: dict, api=None, gen=None, data=None):
+        import yaml
+
+        from syntk.pipelines.bootstrap import _merge_yaml_config
+
+        cfg = tmp_path / "c.yaml"
+        cfg.write_text(yaml.safe_dump(config))
+        api = api or APIArguments()
+        gen = gen or GenerationArguments()
+        data = data or BootstrapDataArguments()
+        _merge_yaml_config(
+            str(cfg),
+            [api, gen, data],
+            (APIArguments, GenerationArguments, BootstrapDataArguments),
+        )
+        return api, gen, data
+
+    def test_yaml_values_applied_when_cli_at_default(self, tmp_path):
+        api, gen, data = self._merge(
+            tmp_path, {"model": "yaml-model", "n": 99, "n_shots": 7}
+        )
+        assert api.model == "yaml-model"   # was default → take YAML
+        assert data.n == 99
+        assert data.n_shots == 7
+
+    def test_cli_value_overrides_yaml(self, tmp_path):
+        # data.n is explicitly set (differs from the default 10) → CLI wins.
+        data = BootstrapDataArguments(n=5)
+        _, _, data = self._merge(tmp_path, {"n": 99}, data=data)
+        assert data.n == 5
+
+    def test_empty_yaml_is_noop(self, tmp_path):
+        api, _, data = self._merge(tmp_path, {})
+        assert api.model == APIArguments().model
+        assert data.n == BootstrapDataArguments().n


### PR DESCRIPTION
## Bug
The README documents that `syntk bootstrap` accepts a positional YAML config ("a YAML config file may be passed positionally (same shape as the column pipeline)"). But `bootstrap.main()` only did half the job:

```python
args_to_parse = None
if sys.argv[1].endswith((".yaml", ".yml")) and not sys.argv[1].startswith("--"):
    args_to_parse = sys.argv[2:]      # slice the YAML path off the front…
...
parser.parse_args_into_dataclasses(args=args_to_parse)   # …and never read the file
```

The YAML path was sliced off argv and **never loaded**, so `syntk bootstrap config.yaml` silently ignored the config and every unset flag fell back to its default.

The column pipeline does it correctly via `BasePipeline.parse_arguments` / `_merge_yaml_config` (captures the path, `yaml.safe_load` → `parse_dict` → merge). Bootstrap just never got that second half.

## Fix
- Capture `config_file = sys.argv[1]` (was dropped).
- Add `_merge_yaml_config` mirroring base.py: `yaml.safe_load` → `HfArgumentParser.parse_dict(allow_extra_keys=True)` → merge with **CLI > YAML > default** precedence.
- Call it from `main()` when a positional YAML is present.

Makes the documented behaviour real; no README change needed.

## Tests
3 new `TestMergeYamlConfig` cases — YAML applied when CLI is at default, CLI overrides YAML, empty YAML is a no-op. They **fail on the old code** (the function didn't exist) and pass with the fix. Full suite **358 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)