### PR TITLE
fix(bootstrap): call get_chat_response correctly (broken against a real API)

### DIFF
--- a/src/syntk/api_client.py
+++ b/src/syntk/api_client.py
@@ -19,6 +19,7 @@ def get_chat_response(
     frequency_penalty: Optional[float] = None,
     presence_penalty: Optional[float] = None,
     return_raw: bool = False,
+    system_prompt: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Get response from OpenAI-compatible API.
 
@@ -32,6 +33,7 @@ def get_chat_response(
         frequency_penalty: Frequency penalty (optional)
         presence_penalty: Presence penalty (optional)
         return_raw: If True, include raw request/response in result
+        system_prompt: Optional system message prepended before the user prompt
 
     Returns:
         Dict with keys:
@@ -48,10 +50,16 @@ def get_chat_response(
         else f"API Call - Prompt: {prompt}"
     )
 
+    # Build the message list: optional system message, then the user prompt.
+    messages = []
+    if system_prompt is not None:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": prompt})
+
     # Build kwargs dict, only including non-None values
     kwargs = {
         "model": model,
-        "messages": [{"role": "user", "content": prompt}],
+        "messages": messages,
     }
 
     if temperature is not None:

--- a/src/syntk/pipelines/bootstrap.py
+++ b/src/syntk/pipelines/bootstrap.py
@@ -166,26 +166,24 @@ def bootstrap(
         examples = random.sample(existing_rows, k)
 
         user_msg = _build_user_message(examples, columns)
-        messages = [
-            {"role": "system", "content": data_args.system_prompt},
-            {"role": "user", "content": user_msg},
-        ]
 
-        response = get_chat_response(
+        api_result = get_chat_response(
             client=client,
-            messages=messages,
+            prompt=user_msg,
             model=api_args.model,
+            system_prompt=data_args.system_prompt,
             **gen_kwargs,
         )
 
-        if response is None:
-            logger.warning("API returned None response, skipping row")
+        content = api_result["content"]
+        if content is None:
+            logger.warning("API returned no content, skipping row")
             failed += 1
             continue
 
-        parsed = _parse_row_response(response, columns)
+        parsed = _parse_row_response(content, columns)
         if parsed is None:
-            logger.warning(f"Could not parse LLM response as JSON row: {response[:200]!r}")
+            logger.warning(f"Could not parse LLM response as JSON row: {content[:200]!r}")
             failed += 1
             continue
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -137,10 +137,11 @@ class TestBootstrap:
         call_iter = iter(responses)
 
         def fake_get_chat_response(**kwargs):
+            # get_chat_response returns a dict; bootstrap reads ["content"].
             try:
-                return next(call_iter)
+                return {"content": next(call_iter)}
             except StopIteration:
-                return None
+                return {"content": None}
 
         with patch("syntk.pipelines.bootstrap.get_chat_response", side_effect=fake_get_chat_response):
             return bootstrap(client, df, data_args, _api_args(), _gen_args())
@@ -183,7 +184,7 @@ class TestBootstrap:
         resp = '{"text": "a", "label": 0}'
         df = _df(20)
 
-        with patch("syntk.pipelines.bootstrap.get_chat_response", return_value=resp):
+        with patch("syntk.pipelines.bootstrap.get_chat_response", return_value={"content": resp}):
             r1 = bootstrap(MagicMock(), df, _data_args(n=3, seed=99), _api_args(), _gen_args())
             r2 = bootstrap(MagicMock(), df, _data_args(n=3, seed=99), _api_args(), _gen_args())
 
@@ -198,8 +199,8 @@ class TestBootstrap:
         call_count = []
 
         def fake_resp(**kwargs):
-            call_count.append(kwargs["messages"])
-            return resp
+            call_count.append(kwargs["prompt"])
+            return {"content": resp}
 
         with patch("syntk.pipelines.bootstrap.get_chat_response", side_effect=fake_resp):
             result = bootstrap(
@@ -209,6 +210,31 @@ class TestBootstrap:
         assert len(result) == 3
         # After the first row, pool grows — later prompts may include generated rows
         # (The test just verifies no crash and correct count)
+
+    def test_real_get_chat_response_contract(self):
+        """Mock the OpenAI *client* (not get_chat_response) so the real call path
+        runs: bootstrap must pass `prompt=`/`system_prompt=` (not `messages=`)
+        and read `["content"]` off the dict return. Mocking get_chat_response
+        directly hid this — the call raised TypeError against a real client."""
+        df = _df(3)
+        message = MagicMock()
+        message.content = '{"text": "x", "label": 1}'
+        del message.reasoning_content  # simulate no reasoning attr
+        choice = MagicMock()
+        choice.message = message
+        choice.finish_reason = "stop"
+        response = MagicMock()
+        response.choices = [choice]
+        response.usage = None
+        client = MagicMock()
+        client.chat.completions.create.return_value = response
+
+        result = bootstrap(client, df, _data_args(n=2), _api_args(), _gen_args())
+
+        assert len(result) == 2
+        # The system prompt must be forwarded as a leading system message.
+        sent = client.chat.completions.create.call_args.kwargs["messages"]
+        assert [m["role"] for m in sent] == ["system", "user"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_get_chat_response.py
+++ b/tests/test_get_chat_response.py
@@ -102,6 +102,15 @@ class TestGetChatResponse:
         assert kwargs["model"] == "gpt-3.5-turbo"
         assert kwargs["messages"] == [{"role": "user", "content": "my prompt"}]
 
+    def test_system_prompt_prepended_as_system_message(self):
+        client = _make_client()
+        get_chat_response(client, "u", "gpt-4", system_prompt="be terse")
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["messages"] == [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "u"},
+        ]
+
     def test_temperature_included_when_set(self):
         client = _make_client()
         get_chat_response(client, "q", "gpt-4", temperature=0.7)


### PR DESCRIPTION
## Bug (ship-breaking — bootstrap can't run against a real API)
`bootstrap()` called the API helper like this:

```python
messages = [{"role": "system", ...}, {"role": "user", ...}]
response = get_chat_response(client=client, messages=messages, model=..., **gen_kwargs)
...
parsed = _parse_row_response(response, columns)   # response.strip()
```

But `api_client.get_chat_response(client, prompt: str, model, ...) -> dict` takes **`prompt`, not `messages`**, and returns a **dict** `{"content", "reasoning_content", "stop_reason"}`, not a string (see how the column pipeline uses it: `prompt=...` then `api_result["content"]`).

So against a real client, every generation raised:

```
TypeError: get_chat_response() got an unexpected keyword argument 'messages'
```

and even past that, `_parse_row_response(response)` would `.strip()` a dict. **The bootstrap tests passed only because they mocked `get_chat_response` to return a string** — the broken integration was never exercised.

There's also a gap: bootstrap's design uses a `system_prompt`, but `get_chat_response` had no way to send one.

## Fix
- **api_client:** add an optional `system_prompt` to `get_chat_response`; it prepends a system message when set. **Backward compatible** — column-pipeline calls (no `system_prompt`) produce the same user-only message as before.
- **bootstrap:** call with `prompt=user_msg, system_prompt=data_args.system_prompt`, read `api_result["content"]`, and skip rows whose content is `None`.
- **tests:** fix the bootstrap mocks to the real dict contract; add `test_real_get_chat_response_contract` that mocks the **client** (not the helper) so the real call path runs — it **errors on the old code** (`TypeError … 'messages'`) and passes now. Added a `system_prompt` test for `get_chat_response`.

Full suite **360 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)